### PR TITLE
Change upgrade items to be named buildings

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,19 +14,19 @@
             <h3>Total Kitties: 0</h3>
             <img src="./assets/catimage.png" class="cat-img">
         </div>
-        <div class="upgrades-container">
-            <div class="upgrade">
-                <div class="upgrade-icon">
+        <div class="building-container">
+            <div class="building">
+                <div class="building-icon">
                     <img src="./assets/mano-click-clip-art-at-hands-16.png">
                 </div>
-                <div class="upgrade-info">
+                <div class="building-info">
                     <h4>Clicker</h4>
-                    <div class="upgrade-cost-info">
-                        <p>Cost: <span class="upgrade-cost">10</span></p>
+                    <div class="building-cost-info">
+                        <p>Cost: <span class="building-cost">10</span></p>
                         <img src="./assets/catcoin.png" class="currency-img">
                     </div>
                 </div>
-                <div class="upgrade-level">
+                <div class="building-level">
                     Lvl 0
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -33,7 +33,7 @@ body {
     transform: scale(1.05);
 }
 
-.upgrade {
+.building {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -45,35 +45,35 @@ body {
     background-color: white;
 }
 
-.upgrade h4 {
+.building h4 {
     margin: 0;
     margin-bottom: 20px;
     font-size: 20px;
 }
 
-.upgrade p {
+.building p {
     margin: 0;
 }
 
-.upgrade-icon img {
+.building-icon img {
     width: 55px;
 }
 
-.upgrade-info {
+.building-info {
     font-size: 40;
 }
 
-.upgrade-info .currency-img {
+.building-info .currency-img {
     width: 20px;
     height: 20px;
 }
 
-.upgrade-cost-info {
+.building-cost-info {
     display: flex;
     align-items: center;
     gap: 5px;
 }
 
-.upgrade-level {
+.building-level {
     font-size: 40;
 }


### PR DESCRIPTION
Closes #2 

All HTML items named "upgrade" or reference upgrades (upgrade-cost-info, upgrade-cost, upgrade-icon) etc are now named more accurately "building" (building, building-cost-info, building-cost, building-icon). 
The CSS has been updated as well. The page remains the same otherwise. 